### PR TITLE
device_handbrake: Warn when simulation lags behind real time

### DIFF
--- a/device_handbrake/docs/README.txt
+++ b/device_handbrake/docs/README.txt
@@ -12,4 +12,9 @@ to keep realtimeness if the poking is 2ms or less.
 Note3: The simulation will run for one poke period before the handbrake starts.
 So expect to see simulations to last approx. 1 poke period less than specified
 
+Note4: If the host machine is too slow to keep up with the requested ratio,
+the handbrake will not stall the simulation. In that case a warning will be
+printed at verbosity level 4 indicating how far behind real time the
+simulation is lagging.
+
 Run with --help for more information

--- a/device_handbrake/src/bs_handbrake_main.c
+++ b/device_handbrake/src/bs_handbrake_main.c
@@ -68,6 +68,8 @@ int main(int argc, char *argv[]) {
         break;
       }
       bs_trace_raw(6,"@%"PRItime" Stalled until real time = %"PRIuMAX"\n", wait_s.end, (uintmax_t)Expected_time);
+    } else {
+      bs_trace_raw(4,"@%"PRItime" Simulation lagging behind real time by %"PRIi64" us\n", wait_s.end, -diff);
     }
   }
 


### PR DESCRIPTION
When the host is too slow to keep up with the requested ratio, the
handbrake silently skips stalling. Add a trace message at level 4 to
indicate how far behind real time the simulation is lagging.
Document this behavior in the README.

Use trace level 4 instead of bs_trace_warning_line because lagging
behind real time is expected under high load and not an error condition.
Using warning level would flood the output in normal use cases.

Level 4 is used (rather than 6, which is used for normal stall messages)
to make the lag more visible since it indicates the handbrake is not
achieving the requested ratio.