### PR TITLE
libPhyComv1: send messages with a single writev

### DIFF
--- a/libPhyComv1/src/bs_pc_base.h
+++ b/libPhyComv1/src/bs_pc_base.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <sys/uio.h>
 #include "bs_types.h"
 #include "bs_pc_base_types.h"
 
@@ -68,8 +69,12 @@ BSIM_INLINE void pb_send_msg(int ff, pc_header_t header,
                              void *s, size_t s_size) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
-    write(ff, &header, sizeof(header));
-    write(ff, s, s_size);
+    struct iovec iov[2] = {
+      { .iov_base = &header, .iov_len = sizeof(header) },
+      { .iov_base = s, .iov_len = s_size },
+    };
+
+    writev(ff, iov, s_size ? 2 : 1);
 #pragma GCC diagnostic pop
 }
 


### PR DESCRIPTION
pb_send_msg() currently writes the message header and payload with two separate write() calls. This is functionally correct, but it gives the scheduler a chance to preempt the sender after the header has been delivered and before the payload is written. In that case the receiver can observe a partial message and block waiting for the remaining bytes.

Use writev() to submit the header and payload in one syscall while keeping the wire format unchanged. Header-only messages continue to write just the header. This also reduces the syscall count for the common header-plus-payload path used by device and PHY messages.